### PR TITLE
Refactor MediaPlayer.reset(): create fresh mediaElement each time to …

### DIFF
--- a/libjs/libmediabridge.js
+++ b/libjs/libmediabridge.js
@@ -3,9 +3,12 @@
 export default {
     async Java_pl_zb3_freej2me_bridge_media_MediaBridge_createMediaPlayer(lib) {
         const player = window.libmedia.createMediaPlayer();
-        player.addEventListener('end-of-media', () => {
-            window.emulator.call('pl/zb3/freej2me/bridge/media/MediaBridge', 'playerEndOfMedia', [player]);
-        });
+        if (!player.__eomHook) {
+            player.addEventListener('end-of-media', () => {
+                window.emulator.call('pl/zb3/freej2me/bridge/media/MediaBridge', 'playerEndOfMedia', [player]);
+            });
+            player.__eomHook = true;
+        }
         return player;
     },
     async Java_pl_zb3_freej2me_bridge_media_MediaBridge_createPlayer(lib) {


### PR DESCRIPTION
…avoid race conditions

- Old mediaElement paused, nodes disconnected, ObjectURL revoked
- New element created, events forwarded, fresh ObjectURL assigned
- Rebuild AudioContext chain; wait for loadeddata/error once
- Added __eomHook flag to avoid duplicate end-of-media listeners